### PR TITLE
fixed sidebar users

### DIFF
--- a/unanimity/src/components/Sidebar/Sidebar.js
+++ b/unanimity/src/components/Sidebar/Sidebar.js
@@ -152,8 +152,6 @@ class Sidebar extends Component {
                                                      <div 
                                                         onClick = { ( ) => { 
 
-
-                                                            this.props.toggleSidebar(true);
                                                             this.props.setCurrentChatRoomID( currentChatRoomID ) } 
 
                                                         }
@@ -175,7 +173,7 @@ class Sidebar extends Component {
 
                                                         </div>
 
-                                                        <h3> { e.data } </h3>
+                                                        <h3 onClick={( ) => { this.props.toggleSidebar(true) }}> { e.data } </h3>
 
                                                     </div>
 


### PR DESCRIPTION
sidebar would close when anything was clicked. i assigned the on click event to the h3 (user) which solved the sidebar closing on removing a chatroom.